### PR TITLE
refs: #2 サイト内で使用しているマップをGoogle Mapに変更する

### DIFF
--- a/src/components/Access.jsx
+++ b/src/components/Access.jsx
@@ -1,0 +1,26 @@
+export default function Access() {
+  const googleMapsUrl =
+    "https://www.google.com/maps/search/?api=1&query=日本大学文理学部";
+
+  return (
+    <section id="access">
+      <h2>アクセス</h2>
+
+      <p>
+        主な活動場所は
+        <br />
+        日本大学文理学部 8号館2階 計算機室です。
+      </p>
+
+      <p>
+        <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer">
+          Googleマップで開く
+        </a>
+      </p>
+
+      <p className="access-note">
+        ※開催場所が変更になる場合があります。参加前に最新のお知らせをご確認ください。
+      </p>
+    </section>
+  );
+}

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import Access from "./Access.jsx";
 
 /* ===== お知らせ ===== */
 function Notice() {
@@ -287,18 +288,7 @@ export default function MainContent() {
         </iframe>
       </section>
 
-      <section id="access">
-        <h2>アクセス</h2>
-        <div className="map-container">
-          日本大学文理学部8号館2階計算機室が主な活動場所です。
-          <iframe
-            src="https://www.openstreetmap.org/export/embed.html?bbox=139.632225%2C35.66001%2C139.636225%2C35.66401&layer=mapnik&marker=35.66201%2C139.634225"
-            style={{ border: 0, width: "100%", height: "300px" }}
-            loading="lazy"
-            title="OpenStreetMap"
-          ></iframe>
-        </div>
-      </section>
+      <Access />
     </main>
   );
 }


### PR DESCRIPTION
## 概要

アクセスセクションを簡素化しました。
地図の埋め込みは削除し、Googleマップへのリンクのみを設置しています。

## 変更内容

* `Access` コンポーネントを追加
* OpenStreetMap の埋め込み地図を削除
* Googleマップへのリンクを設置

## 意図

* 所在地確認のみできれば十分なため
* Google Maps API 等の設定（課金・クレカ登録）を避けるため
* デザイン実装を別PRで行いやすくするため

## デザインについて

本PRでは構造のみ実装しています。
スタイル調整・レイアウトは別途対応予定です。
- #8 

## 動作確認

* Googleマップリンクから日本大学文理学部の位置が開くことの確認をお願いします