### PR TITLE
refs: #13 タブタイトルの変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>LoGeek公式サイト</title>
+    <title>LoGeek</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
   </head>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -18,7 +18,6 @@ export default function Header() {
   />
   <span className="site-title">LoGeek</span>
 </div>
-        <div className="site-title">LoGeek公式サイト</div>
       </div>
       <button
         className="menu-toggle"


### PR DESCRIPTION
### 概要
サブタイトルとヘッダーのタイトルを「LoGeek公式サイト」→「LoGeek」
ヘッダーのタイトルは重複していたため一つにしました。

### 確認してほしいこと
タイトルが適切に変更されているか

