### PR TITLE
refs: #5 モバイル対応

### DIFF
--- a/src/Hero.jsx
+++ b/src/Hero.jsx
@@ -29,7 +29,7 @@ export default function Hero() {
       <img src="/top.jpg" alt="メインイメージ" className="hero-image" />
       <div className="hero-text">
         <h1 className="hero-title">LoGeek</h1>
-        <p>情報技術を、ともに深める</p>
+        <p>情報技術を、<br className="br-sp" />ともに深める</p>
       </div>
     </div>
   );

--- a/src/components/Access.jsx
+++ b/src/components/Access.jsx
@@ -13,7 +13,7 @@ export default function Access() {
       <img
         src="/LocalMap.png"
         alt={"学科計算機室への案内図：日本大学文理学部 8号館 2階"}
-        style={{ width: 480, objectFit: "cover" }}
+        class="map-image"
       />
 
       <p>

--- a/src/index.css
+++ b/src/index.css
@@ -224,6 +224,10 @@ section h2 {
   border-color: #111827;
 }
 
+.br-sp {
+  display: inline;
+}
+
 @media (min-width: 768px) {
   .hero {
     position: relative;
@@ -254,5 +258,9 @@ section h2 {
   .map-image {
     width: 60%;
     object-fit: cover;
+  }
+  
+  .br-sp {
+    display: none;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -136,6 +136,11 @@ section h2 {
   padding-left: 0.5rem;
 }
 
+.map-image {
+  width: 100%;
+  object-fit: cover;
+}
+
 .map-container {
   margin-top: 1rem;
   width: 100%;
@@ -237,5 +242,10 @@ section h2 {
     flex-direction: row;
     gap: 1.5rem;
     padding: 0;
+  }
+
+  .map-image {
+    width: 60%;
+    object-fit: cover;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -156,7 +156,7 @@ section h2 {
 .hero {
   position: relative;
   width: 100%;
-  height: 70vh;
+  height: 90vh;
   overflow: hidden;
 }
 
@@ -225,6 +225,13 @@ section h2 {
 }
 
 @media (min-width: 768px) {
+  .hero {
+    position: relative;
+    width: 100%;
+    height: 70vh;
+    overflow: hidden;
+  }
+
   .site-header {
     padding: 0.75rem 2rem;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -136,27 +136,6 @@ section h2 {
   padding-left: 0.5rem;
 }
 
-@media (min-width: 768px) {
-  .site-header {
-    padding: 0.75rem 2rem;
-  }
-
-  .menu-toggle {
-    display: none;
-  }
-
-  .site-nav {
-    display: block;
-    position: static;
-  }
-
-  .site-nav ul {
-    flex-direction: row;
-    gap: 1.5rem;
-    padding: 0;
-  }
-}
-
 .map-container {
   margin-top: 1rem;
   width: 100%;
@@ -238,4 +217,25 @@ section h2 {
 .link-button:hover {
   background-color: #f9fafb;
   border-color: #111827;
+}
+
+@media (min-width: 768px) {
+  .site-header {
+    padding: 0.75rem 2rem;
+  }
+
+  .menu-toggle {
+    display: none;
+  }
+
+  .site-nav {
+    display: block;
+    position: static;
+  }
+
+  .site-nav ul {
+    flex-direction: row;
+    gap: 1.5rem;
+    padding: 0;
+  }
 }


### PR DESCRIPTION
モバイル対応 #5

### 変更内容
- PC用のCSSを最後に適応されるように変更しました
- アクセスセクションのMAPをレスポンシブ対応。
    - パソコンで開いた時に比べ、スマホで開いた場合の方がマップをより大きく表示するようになっています
- スマホでサイトを開くとヒーロー画像がより大きく表示されます。

### 確認してほしいこと
- 適切に変更が反映されているか？

### 留意事項
PC用のCSS（@media (min-width: 768px) {}）を`index.css`の末尾に移動しました。この変更で他の箇所のレイアウトが崩れていないかご確認お願いします。